### PR TITLE
Fix typos and update reasons in documentation and data

### DIFF
--- a/README.md
+++ b/README.md
@@ -5255,7 +5255,7 @@ https://github.com/ignatandrei/RSCG_Examples/issues/new?title=FastEndpoints&body
 
 14) [FluentAssertions.Eventual]( https://github.com/mazharenko/FluentAssertions.Eventual) , https://github.com/mazharenko/FluentAssertions.Eventual 
 
-Why I have not tested : atchived
+Why I have not tested : archived
 
 https://github.com/ignatandrei/RSCG_Examples/issues/new?title=FluentAssertions.Eventual&body=https://github.com/mazharenko/FluentAssertions.Eventual
 

--- a/v2/RSCGExamplesData/NoExample.json
+++ b/v2/RSCGExamplesData/NoExample.json
@@ -588,7 +588,7 @@
   {
     "ID": 123,
     "name": "FluentAssertions.Eventual https://github.com/mazharenko/FluentAssertions.Eventual",
-    "why": "atchived"
+    "why": "archived"
   },
   {
     "ID": 124,
@@ -855,7 +855,7 @@
   {
     "ID":206,
     "name":"https://github.com/ionite34/MinimalApiMapper",
-    "why":"later"
+    "why":"own idea where to generate files, so overwrites"
   },
   {
     "ID":210,

--- a/v2/rscg_examples_site/docs/NoExamples.md
+++ b/v2/rscg_examples_site/docs/NoExamples.md
@@ -208,7 +208,7 @@ Why I have not put example: old ISourceGenerator
 
 51)FluentAssertions.Eventual https://github.com/mazharenko/FluentAssertions.Eventual  
 
-Why I have not put example: atchived
+Why I have not put example: archived
 
 52)FluentBuilder https://github.com/StefH/FluentBuilder  
 


### PR DESCRIPTION
Corrected 'atchived' to 'archived' for FluentAssertions.Eventual in README, NoExample.json, and NoExamples.md. Updated the reason for MinimalApiMapper in NoExample.json to clarify its file generation approach.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected typos in README and NoExamples documentation, updating “atchived” to “archived” for FluentAssertions.Eventual.
  * Clarified phrasing around reasons for missing examples.

* **Chores**
  * Updated data entries to fix a typo (“atchived” → “archived”) and refined explanation text (“later” → “own idea where to generate files, so overwrites”) for improved clarity in displayed reasons.
  * No functional changes; content updates only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->